### PR TITLE
[scripts] not use latest wrapt version

### DIFF
--- a/script/otbr-setup.bash
+++ b/script/otbr-setup.bash
@@ -96,6 +96,7 @@ fi
 # nRF Connect SDK related actions
 if [ "${REFERENCE_PLATFORM?}" = "ncs" ]; then
   apt-get install -y --no-install-recommends vim wiringpi
+  pip install wrapt==1.12.1
   pip install nrfutil
 
   # add calling of link_dongle.py script at startup to update symlink to the dongle


### PR DESCRIPTION
Latest wrapt version does not build. Installing working version prior to
installing nrfutil in order to satisfy its dependencies.

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>